### PR TITLE
Graphs improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "oa-graphs"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oa-graphs"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Hardware Graphs",
   "Author": "Victor Marin",
-  "Version": "1.0.0",
+  "Version": "1.1.0",
   "CodePaths": {
     "x86_64-unknown-linux-gnu": "oa-graphs-x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu": "oa-graphs-aarch64-unknown-linux-gnu"

--- a/pi.html
+++ b/pi.html
@@ -27,9 +27,13 @@
                     document.getElementById("lmsensors_section");
                 const websocketSection =
                     document.getElementById("websocket_section");
+                const websocketBanner =
+                    document.getElementById("websocket_banner");
                 const metricType = document.getElementById("metric_type");
                 const fanNumber = document.getElementById("fan_number");
                 const fanNumberSection = document.getElementById("fan_number_section");
+                const gpuCardSection = document.getElementById("gpu_card_section");
+                const gpuCard = document.getElementById("gpu_card");
                 const visualizationType = document.getElementById("visualization_type");
                 const showValueText =
                     document.getElementById("show_value_text");
@@ -60,6 +64,9 @@
                 websocketUrl.value = settings.websocket_url || "";
                 websocketApiKey.value = settings.websocket_api_key || "";
 
+                // Store current gpu_card from settings to restore after GPU list loads
+                let savedGpuCard = settings.gpu_card || "";
+
                 // Initialize init messages
                 const initMessages = settings.websocket_init_messages || [];
                 renderInitMessages(initMessages);
@@ -67,6 +74,7 @@
                 // Show/hide sections based on data source and metric type
                 toggleDataSourceSections();
                 toggleFanNumberSection();
+                toggleGpuCardSection();
 
                 websocket.onmessage = (event) => {
                     const data = JSON.parse(event.data);
@@ -84,21 +92,53 @@
                         minValue.value = s.min_value ?? "";
                         websocketUrl.value = s.websocket_url || "";
                         websocketApiKey.value = s.websocket_api_key || "";
+                        savedGpuCard = s.gpu_card || "";
+                        if (gpuCard.options.length > 0) {
+                            gpuCard.value = savedGpuCard;
+                        }
 
                         const msgs = s.websocket_init_messages || [];
                         renderInitMessages(msgs);
                         toggleDataSourceSections();
                         toggleFanNumberSection();
+                        toggleGpuCardSection();
+                    } else if (data.event == "sendToPropertyInspector") {
+                        const payload = data.payload || {};
+                        if (payload.event === "gpuList") {
+                            populateGpuList(payload.gpus || [], savedGpuCard);
+                        }
                     }
                 };
+
+                function populateGpuList(gpus, selectedCard) {
+                    gpuCard.innerHTML = "";
+                    if (gpus.length === 0) {
+                        const opt = document.createElement("option");
+                        opt.value = "card0";
+                        opt.textContent = "card0 (default)";
+                        gpuCard.appendChild(opt);
+                    } else {
+                        gpus.forEach((gpu) => {
+                            const opt = document.createElement("option");
+                            opt.value = gpu.card;
+                            opt.textContent = gpu.name;
+                            gpuCard.appendChild(opt);
+                        });
+                    }
+                    if (selectedCard) {
+                        gpuCard.value = selectedCard;
+                    }
+                }
 
                 function toggleDataSourceSections() {
                     if (dataSource.value === "lmsensors") {
                         lmSensorsSection.style.display = "block";
                         websocketSection.style.display = "none";
+                        websocketBanner.style.display = "none";
                     } else {
                         lmSensorsSection.style.display = "none";
                         websocketSection.style.display = "block";
+                        websocketBanner.style.display = "flex";
                     }
                 }
 
@@ -108,6 +148,12 @@
                     } else {
                         fanNumberSection.style.display = "none";
                     }
+                }
+
+                function toggleGpuCardSection() {
+                    const isGpuMetric = dataSource.value === "lmsensors" &&
+                        (metricType.value === "gputemp" || metricType.value === "gpuload");
+                    gpuCardSection.style.display = isGpuMetric ? "block" : "none";
                 }
 
                 function renderInitMessages(messages) {
@@ -150,11 +196,13 @@
                 window.dataSourceChanged = () => {
                     toggleDataSourceSections();
                     toggleFanNumberSection();
+                    toggleGpuCardSection();
                     update();
                 };
 
                 window.metricTypeChanged = () => {
                     toggleFanNumberSection();
+                    toggleGpuCardSection();
                     update();
                 };
 
@@ -174,6 +222,13 @@
                         // Fan number for system fan
                         if (metricType.value === "systemfan" && fanNumber.value) {
                             settings.fan_number = parseInt(fanNumber.value);
+                        }
+
+                        // GPU card selection for GPU metrics
+                        if (metricType.value === "gputemp" || metricType.value === "gpuload") {
+                            if (gpuCard.value) {
+                                settings.gpu_card = gpuCard.value;
+                            }
                         }
                     }
 
@@ -323,6 +378,26 @@
             .btn-add:hover {
                 background-color: oklch(40% 0 0);
             }
+            .banner {
+                display: none;
+                align-items: flex-start;
+                gap: 8px;
+                padding: 10px 12px;
+                border-radius: 6px;
+                margin-bottom: 16px;
+                font-size: 13px;
+                line-height: 1.4;
+            }
+            .banner-warning {
+                background-color: oklch(35% 0.08 60);
+                border: 1px solid oklch(55% 0.12 60);
+                color: oklch(90% 0.05 60);
+            }
+            .banner-icon {
+                font-size: 16px;
+                flex-shrink: 0;
+                line-height: 1.4;
+            }
         </style>
     </head>
     <body>
@@ -332,6 +407,11 @@
                 <option value="lmsensors">LM Sensors</option>
                 <option value="websocket">WebSocket</option>
             </select>
+        </div>
+
+        <div id="websocket_banner" class="banner banner-warning">
+            <span class="banner-icon">⚠</span>
+            <span><strong>Experimental:</strong> WebSocket mode may not work properly in all setups.</span>
         </div>
 
         <!-- LM Sensors Section -->
@@ -373,6 +453,16 @@
                 />
                 <div class="help-text">
                     Select which fan sensor to monitor (fan1, fan2, etc.)
+                </div>
+            </div>
+
+            <div id="gpu_card_section" class="field" style="display: none">
+                <label for="gpu_card">GPU:</label>
+                <select id="gpu_card" oninput="update();">
+                    <option value="card0">card0 (default)</option>
+                </select>
+                <div class="help-text">
+                    Select which GPU to monitor
                 </div>
             </div>
         </div>

--- a/src/graph_data.rs
+++ b/src/graph_data.rs
@@ -141,6 +141,9 @@ pub struct GraphSettings {
 
     // Fan settings
     pub fan_number: Option<u32>,
+
+    // GPU selection
+    pub gpu_card: Option<String>,
 }
 
 /// Data for a single graph instance

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -37,8 +37,14 @@ async fn read_lm_sensors_value(settings: &GraphSettings) -> Result<f32> {
     match settings.metric_type {
         MetricType::CpuTemp | MetricType::CpuPackageTemp => sensors::find_cpu_temperature().await,
         MetricType::CpuLoad => sensors::find_cpu_load().await,
-        MetricType::GpuTemp => sensors::find_gpu_temperature().await,
-        MetricType::GpuLoad => sensors::find_gpu_load().await,
+        MetricType::GpuTemp => {
+            let card = settings.gpu_card.as_deref().unwrap_or("card0");
+            sensors::find_gpu_temperature(card).await
+        }
+        MetricType::GpuLoad => {
+            let card = settings.gpu_card.as_deref().unwrap_or("card0");
+            sensors::find_gpu_load(card).await
+        }
         MetricType::MotherboardTemp => sensors::find_motherboard_temperature().await,
         MetricType::NvmeTemp => sensors::find_nvme_temperature().await,
         MetricType::SystemFan => {
@@ -89,6 +95,30 @@ impl Action for GraphAction {
         let mut instances = GRAPH_INSTANCES.lock().await;
         instances.remove(&instance_id);
 
+        Ok(())
+    }
+
+    async fn property_inspector_did_appear(
+        &self,
+        instance: &Instance,
+        _settings: &Self::Settings,
+    ) -> OpenActionResult<()> {
+        let gpus = sensors::list_gpus();
+        let gpu_list: Vec<serde_json::Value> = gpus
+            .iter()
+            .map(|g| {
+                serde_json::json!({
+                    "card": g.card,
+                    "name": g.name,
+                })
+            })
+            .collect();
+        let _ = instance
+            .send_to_property_inspector(serde_json::json!({
+                "event": "gpuList",
+                "gpus": gpu_list,
+            }))
+            .await;
         Ok(())
     }
 

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -20,19 +20,25 @@ enum GpuVendor {
 }
 
 fn detect_gpu_vendor_for_card(card: &str) -> GpuVendor {
-    // Check NVIDIA (system-wide, not per-card via sysfs)
-    if Path::new("/proc/driver/nvidia/version").exists() {
-        return GpuVendor::Nvidia;
-    }
-
     // Check AMD
     if Path::new(&format!("/sys/class/drm/{}/device/gpu_busy_percent", card)).exists() {
         return GpuVendor::Amd;
     }
 
-    // Check Intel
+    // Check Intel via sysfs frequency file
     if Path::new(&format!("/sys/class/drm/{}/gt_cur_freq_mhz", card)).exists() {
         return GpuVendor::Intel;
+    }
+
+    // Check via PCI vendor ID
+    let vendor_path = format!("/sys/class/drm/{}/device/vendor", card);
+    if let Ok(vendor) = fs::read_to_string(&vendor_path) {
+        match vendor.trim() {
+            "0x8086" => return GpuVendor::Intel,
+            "0x10de" => return GpuVendor::Nvidia,
+            "0x1002" => return GpuVendor::Amd,
+            _ => {}
+        }
     }
 
     GpuVendor::Unknown
@@ -63,9 +69,6 @@ pub fn list_gpus() -> Vec<GpuInfo> {
                     }
                 }
             }
-        }
-        if !gpus.is_empty() {
-            return gpus;
         }
     }
 

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -384,7 +384,7 @@ pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
         }
     } else {
         match detect_gpu_vendor_for_card(card) {
-            GpuVendor::Amd => {
+            GpuVendor::Amd | GpuVendor::Intel => {
                 let hwmon_path = format!("/sys/class/drm/{}/device/hwmon", card);
                 if let Ok(entries) = fs::read_dir(&hwmon_path) {
                     for entry in entries.flatten() {

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -19,23 +19,124 @@ enum GpuVendor {
     Unknown,
 }
 
-fn detect_gpu_vendor() -> GpuVendor {
-    // Check NVIDIA
+fn detect_gpu_vendor_for_card(card: &str) -> GpuVendor {
+    // Check NVIDIA (system-wide, not per-card via sysfs)
     if Path::new("/proc/driver/nvidia/version").exists() {
         return GpuVendor::Nvidia;
     }
 
     // Check AMD
-    if Path::new("/sys/class/drm/card0/device/gpu_busy_percent").exists() {
+    if Path::new(&format!("/sys/class/drm/{}/device/gpu_busy_percent", card)).exists() {
         return GpuVendor::Amd;
     }
 
     // Check Intel
-    if Path::new("/sys/class/drm/card0/gt_cur_freq_mhz").exists() {
+    if Path::new(&format!("/sys/class/drm/{}/gt_cur_freq_mhz", card)).exists() {
         return GpuVendor::Intel;
     }
 
     GpuVendor::Unknown
+}
+
+/// Represents a detected GPU with its card name and display name
+#[derive(Debug, Clone)]
+pub struct GpuInfo {
+    pub card: String,
+    pub name: String,
+}
+
+/// Enumerate all available GPUs from /sys/class/drm
+pub fn list_gpus() -> Vec<GpuInfo> {
+    let mut gpus = Vec::new();
+
+    // Check for NVIDIA GPUs via NVML
+    if Path::new("/proc/driver/nvidia/version").exists() {
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(count) = nvml.device_count() {
+                for i in 0..count {
+                    if let Ok(device) = nvml.device_by_index(i) {
+                        let name = device.name().unwrap_or_else(|_| format!("NVIDIA GPU {}", i));
+                        gpus.push(GpuInfo {
+                            card: format!("nvidia:{}", i),
+                            name: format!("NVIDIA {} (GPU {})", name, i),
+                        });
+                    }
+                }
+            }
+        }
+        if !gpus.is_empty() {
+            return gpus;
+        }
+    }
+
+    // Enumerate DRM cards
+    let drm_path = Path::new("/sys/class/drm");
+    if let Ok(entries) = fs::read_dir(drm_path) {
+        let mut cards: Vec<String> = entries
+            .flatten()
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                // Only top-level cardN entries (not cardN-HDMI-A-1 etc.)
+                if name.starts_with("card") && name.chars().skip(4).all(|c| c.is_ascii_digit()) {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        cards.sort();
+
+        for card in cards {
+            // Try to read GPU name from device/product_name or uevent
+            let name = read_gpu_name(&card);
+            let vendor = detect_gpu_vendor_for_card(&card);
+            let vendor_prefix = match vendor {
+                GpuVendor::Amd => "AMD",
+                GpuVendor::Intel => "Intel",
+                _ => "GPU",
+            };
+            let display_name = if name.is_empty() {
+                format!("{} {} ({})", vendor_prefix, card, card)
+            } else {
+                format!("{} - {}", card, name)
+            };
+            gpus.push(GpuInfo {
+                card: card.clone(),
+                name: display_name,
+            });
+        }
+    }
+
+    gpus
+}
+
+fn read_gpu_name(card: &str) -> String {
+    // Try PCI device name from uevent
+    let uevent_path = format!("/sys/class/drm/{}/device/uevent", card);
+    if let Ok(content) = fs::read_to_string(&uevent_path) {
+        for line in content.lines() {
+            if let Some(val) = line.strip_prefix("PCI_ID=") {
+                // val is something like "1002:744C" — look up in pci.ids or just return the ID
+                return val.to_string();
+            }
+        }
+    }
+
+    // Try hwmon name as fallback
+    let hwmon_base = format!("/sys/class/drm/{}/device/hwmon", card);
+    if let Ok(entries) = fs::read_dir(&hwmon_base) {
+        for entry in entries.flatten() {
+            let name_path = entry.path().join("name");
+            if let Ok(name) = fs::read_to_string(name_path) {
+                let name = name.trim().to_string();
+                if !name.is_empty() {
+                    return name;
+                }
+            }
+        }
+    }
+
+    String::new()
 }
 
 /// Find CPU load percentage by reading /proc/stat
@@ -230,68 +331,88 @@ pub async fn find_cpu_temperature() -> Result<f32> {
     Ok(0.0)
 }
 
-/// Find GPU load percentage
-pub async fn find_gpu_load() -> Result<f32> {
-    match detect_gpu_vendor() {
-        GpuVendor::Amd => {
-            // AMD GPU load from sysfs
-            if let Ok(load_str) = fs::read_to_string("/sys/class/drm/card0/device/gpu_busy_percent")
-            {
-                if let Ok(load) = load_str.trim().parse::<f32>() {
-                    return Ok(load);
+/// Find GPU load percentage for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_load(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(utilization) = device.utilization_rates() {
+                    return Ok(utilization.gpu as f32);
                 }
             }
         }
-        GpuVendor::Nvidia => {
-            // NVIDIA GPU load using NVML
-            if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                if let Ok(device) = nvml.device_by_index(0) {
-                    if let Ok(utilization) = device.utilization_rates() {
-                        return Ok(utilization.gpu as f32);
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let path = format!("/sys/class/drm/{}/device/gpu_busy_percent", card);
+                if let Ok(load_str) = fs::read_to_string(&path) {
+                    if let Ok(load) = load_str.trim().parse::<f32>() {
+                        return Ok(load);
                     }
                 }
             }
-        }
-        _ => {}
-    }
-
-    log::warn!("GPU load sensor not found");
-    Ok(0.0)
-}
-
-/// Find GPU temperature from lm-sensors
-pub async fn find_gpu_temperature() -> Result<f32> {
-    match detect_gpu_vendor() {
-        GpuVendor::Amd => {
-            // AMD GPU temperature from sysfs hwmon
-            let hwmon_path = "/sys/class/drm/card0/device/hwmon";
-            if let Ok(entries) = fs::read_dir(hwmon_path) {
-                for entry in entries.flatten() {
-                    let temp_path = entry.path().join("temp1_input");
-                    if let Ok(temp_str) = fs::read_to_string(temp_path) {
-                        if let Ok(temp_millis) = temp_str.trim().parse::<f32>() {
-                            return Ok(temp_millis / 1000.0);
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(utilization) = device.utilization_rates() {
+                            return Ok(utilization.gpu as f32);
                         }
                     }
                 }
             }
+            _ => {}
         }
-        GpuVendor::Nvidia => {
-            // NVIDIA GPU temperature using NVML
-            if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                if let Ok(device) = nvml.device_by_index(0) {
-                    if let Ok(temp) = device
-                        .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
-                    {
-                        return Ok(temp as f32);
-                    }
+    }
+
+    log::warn!("GPU load sensor not found for card: {}", card);
+    Ok(0.0)
+}
+
+/// Find GPU temperature for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(temp) = device
+                    .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
+                {
+                    return Ok(temp as f32);
                 }
             }
         }
-        _ => {}
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let hwmon_path = format!("/sys/class/drm/{}/device/hwmon", card);
+                if let Ok(entries) = fs::read_dir(&hwmon_path) {
+                    for entry in entries.flatten() {
+                        let temp_path = entry.path().join("temp1_input");
+                        if let Ok(temp_str) = fs::read_to_string(temp_path) {
+                            if let Ok(temp_millis) = temp_str.trim().parse::<f32>() {
+                                return Ok(temp_millis / 1000.0);
+                            }
+                        }
+                    }
+                }
+            }
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(temp) = device
+                            .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
+                        {
+                            return Ok(temp as f32);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
-    log::warn!("GPU temperature sensor not found");
+    log::warn!("GPU temperature sensor not found for card: {}", card);
     Ok(0.0)
 }
 


### PR DESCRIPTION
Updates manifest properly, alongside Cargo file.

Adds an Experimental banner to the websocket settings suggesting it might not work properly.

Allows gpu selection in the interface.

Should now also support Intel integrated gpus in the list of options and allow temp graphs for them. Load percentage was trickier and prone to performance issues so that will not be a part of this.