### PR TITLE
Add GPU VRAM, GPU power, and RAM usage display modes

### DIFF
--- a/pi.html
+++ b/pi.html
@@ -219,6 +219,8 @@
                     toggleDataSourceSections();
                     toggleFanNumberSection();
                     toggleGpuCardSection();
+                    toggleVramDisplaySection();
+                    toggleRamDisplaySection();
                     update();
                 };
 

--- a/pi.html
+++ b/pi.html
@@ -32,6 +32,10 @@
                 const metricType = document.getElementById("metric_type");
                 const fanNumber = document.getElementById("fan_number");
                 const fanNumberSection = document.getElementById("fan_number_section");
+                const vramDisplay = document.getElementById("vram_display");
+                const vramDisplaySection = document.getElementById("vram_display_section");
+                const ramDisplay = document.getElementById("ram_display");
+                const ramDisplaySection = document.getElementById("ram_display_section");
                 const gpuCardSection = document.getElementById("gpu_card_section");
                 const gpuCard = document.getElementById("gpu_card");
                 const visualizationType = document.getElementById("visualization_type");
@@ -56,6 +60,8 @@
                 visualizationType.value = settings.visualization_type || "graph";
                 metricType.value = settings.metric_type || "cputemp";
                 fanNumber.value = settings.fan_number ?? 1;
+                vramDisplay.value = settings.vram_display || "percentage";
+                ramDisplay.value = settings.ram_display || "percentage";
                 showValueText.checked = settings.show_value_text ?? false;
                 normalColor.value = settings.normal_color || "#00ff00";
                 warningColor.value = settings.warning_color || "#ff0000";
@@ -75,6 +81,8 @@
                 toggleDataSourceSections();
                 toggleFanNumberSection();
                 toggleGpuCardSection();
+                toggleVramDisplaySection();
+                toggleRamDisplaySection();
 
                 websocket.onmessage = (event) => {
                     const data = JSON.parse(event.data);
@@ -84,6 +92,8 @@
                         visualizationType.value = s.visualization_type || "graph";
                         metricType.value = s.metric_type || "cputemp";
                         fanNumber.value = s.fan_number ?? 1;
+                        vramDisplay.value = s.vram_display || "percentage";
+                        ramDisplay.value = s.ram_display || "percentage";
                         showValueText.checked = s.show_value_text ?? false;
                         threshold.value = s.threshold ?? "";
                         normalColor.value = s.normal_color || "#00ff00";
@@ -102,6 +112,8 @@
                         toggleDataSourceSections();
                         toggleFanNumberSection();
                         toggleGpuCardSection();
+                        toggleVramDisplaySection();
+                        toggleRamDisplaySection();
                     } else if (data.event == "sendToPropertyInspector") {
                         const payload = data.payload || {};
                         if (payload.event === "gpuList") {
@@ -150,9 +162,19 @@
                     }
                 }
 
+                function toggleVramDisplaySection() {
+                    const isVram = dataSource.value === "lmsensors" && metricType.value === "gpuvram";
+                    vramDisplaySection.style.display = isVram ? "block" : "none";
+                }
+
+                function toggleRamDisplaySection() {
+                    const isRam = dataSource.value === "lmsensors" && metricType.value === "ramusage";
+                    ramDisplaySection.style.display = isRam ? "block" : "none";
+                }
+
                 function toggleGpuCardSection() {
                     const isGpuMetric = dataSource.value === "lmsensors" &&
-                        (metricType.value === "gputemp" || metricType.value === "gpuload");
+                        ["gputemp", "gpuload", "gpuvram", "gpupower"].includes(metricType.value);
                     gpuCardSection.style.display = isGpuMetric ? "block" : "none";
                 }
 
@@ -203,6 +225,8 @@
                 window.metricTypeChanged = () => {
                     toggleFanNumberSection();
                     toggleGpuCardSection();
+                    toggleVramDisplaySection();
+                    toggleRamDisplaySection();
                     update();
                 };
 
@@ -224,8 +248,16 @@
                             settings.fan_number = parseInt(fanNumber.value);
                         }
 
+                        // Memory display mode
+                        if (metricType.value === "gpuvram") {
+                            settings.vram_display = vramDisplay.value;
+                        }
+                        if (metricType.value === "ramusage") {
+                            settings.ram_display = ramDisplay.value;
+                        }
+
                         // GPU card selection for GPU metrics
-                        if (metricType.value === "gputemp" || metricType.value === "gpuload") {
+                        if (["gputemp", "gpuload", "gpuvram", "gpupower"].includes(metricType.value)) {
                             if (gpuCard.value) {
                                 settings.gpu_card = gpuCard.value;
                             }
@@ -426,6 +458,8 @@
                     <option value="cpuload">CPU Load</option>
                     <option value="gputemp">GPU Temperature</option>
                     <option value="gpuload">GPU Load</option>
+                    <option value="gpuvram">GPU VRAM Usage</option>
+                    <option value="gpupower">GPU Power Draw</option>
                     <option value="motherboardtemp">
                         Motherboard Temperature
                     </option>
@@ -453,6 +487,28 @@
                 />
                 <div class="help-text">
                     Select which fan sensor to monitor (fan1, fan2, etc.)
+                </div>
+            </div>
+
+            <div id="vram_display_section" class="field" style="display: none">
+                <label for="vram_display">VRAM Display:</label>
+                <select id="vram_display" oninput="update();">
+                    <option value="percentage">Percentage (%)</option>
+                    <option value="gigabytes">Gigabytes (GB)</option>
+                </select>
+                <div class="help-text">
+                    Show VRAM usage as percentage or absolute GB
+                </div>
+            </div>
+
+            <div id="ram_display_section" class="field" style="display: none">
+                <label for="ram_display">RAM Display:</label>
+                <select id="ram_display" oninput="update();">
+                    <option value="percentage">Percentage (%)</option>
+                    <option value="gigabytes">Gigabytes (GB)</option>
+                </select>
+                <div class="help-text">
+                    Show RAM usage as percentage or absolute GB
                 </div>
             </div>
 

--- a/pi.html
+++ b/pi.html
@@ -23,8 +23,8 @@
 
                 // Get elements
                 const dataSource = document.getElementById("data_source");
-                const lmSensorsSection =
-                    document.getElementById("lmsensors_section");
+                const localSection =
+                    document.getElementById("local_section");
                 const websocketSection =
                     document.getElementById("websocket_section");
                 const websocketBanner =
@@ -56,7 +56,7 @@
 
                 // Set default values from settings
                 const settings = inActionInfo.payload.settings || {};
-                dataSource.value = settings.data_source || "lmsensors";
+                dataSource.value = settings.data_source || "local";
                 visualizationType.value = settings.visualization_type || "graph";
                 metricType.value = settings.metric_type || "cputemp";
                 fanNumber.value = settings.fan_number ?? 1;
@@ -88,7 +88,7 @@
                     const data = JSON.parse(event.data);
                     if (data.event == "didReceiveSettings") {
                         const s = data.payload.settings || {};
-                        dataSource.value = s.data_source || "lmsensors";
+                        dataSource.value = s.data_source || "local";
                         visualizationType.value = s.visualization_type || "graph";
                         metricType.value = s.metric_type || "cputemp";
                         fanNumber.value = s.fan_number ?? 1;
@@ -143,19 +143,19 @@
                 }
 
                 function toggleDataSourceSections() {
-                    if (dataSource.value === "lmsensors") {
-                        lmSensorsSection.style.display = "block";
+                    if (dataSource.value === "local") {
+                        localSection.style.display = "block";
                         websocketSection.style.display = "none";
                         websocketBanner.style.display = "none";
                     } else {
-                        lmSensorsSection.style.display = "none";
+                        localSection.style.display = "none";
                         websocketSection.style.display = "block";
                         websocketBanner.style.display = "flex";
                     }
                 }
 
                 function toggleFanNumberSection() {
-                    if (dataSource.value === "lmsensors" && metricType.value === "systemfan") {
+                    if (dataSource.value === "local" && metricType.value === "systemfan") {
                         fanNumberSection.style.display = "block";
                     } else {
                         fanNumberSection.style.display = "none";
@@ -163,17 +163,17 @@
                 }
 
                 function toggleVramDisplaySection() {
-                    const isVram = dataSource.value === "lmsensors" && metricType.value === "gpuvram";
+                    const isVram = dataSource.value === "local" && metricType.value === "gpuvram";
                     vramDisplaySection.style.display = isVram ? "block" : "none";
                 }
 
                 function toggleRamDisplaySection() {
-                    const isRam = dataSource.value === "lmsensors" && metricType.value === "ramusage";
+                    const isRam = dataSource.value === "local" && metricType.value === "ramusage";
                     ramDisplaySection.style.display = isRam ? "block" : "none";
                 }
 
                 function toggleGpuCardSection() {
-                    const isGpuMetric = dataSource.value === "lmsensors" &&
+                    const isGpuMetric = dataSource.value === "local" &&
                         ["gputemp", "gpuload", "gpuvram", "gpupower"].includes(metricType.value);
                     gpuCardSection.style.display = isGpuMetric ? "block" : "none";
                 }
@@ -241,8 +241,8 @@
                         warning_color: warningColor.value,
                     };
 
-                    // LM Sensors settings
-                    if (dataSource.value === "lmsensors") {
+                    // Local sensor settings
+                    if (dataSource.value === "local") {
                         settings.metric_type = metricType.value;
 
                         // Fan number for system fan
@@ -438,7 +438,7 @@
         <div class="field">
             <label for="data_source">Data Source:</label>
             <select id="data_source" onchange="dataSourceChanged();">
-                <option value="lmsensors">LM Sensors</option>
+                <option value="local">Local Sensors</option>
                 <option value="websocket">WebSocket</option>
             </select>
         </div>
@@ -448,8 +448,8 @@
             <span><strong>Experimental:</strong> WebSocket mode may not work properly in all setups.</span>
         </div>
 
-        <!-- LM Sensors Section -->
-        <div id="lmsensors_section">
+        <!-- Local Sensors Section -->
+        <div id="local_section">
             <div class="field">
                 <label for="metric_type">Metric Type:</label>
                 <select id="metric_type" oninput="metricTypeChanged();">

--- a/src/graph_data.rs
+++ b/src/graph_data.rs
@@ -265,7 +265,19 @@ impl GraphData {
                 .settings
                 .threshold
                 .or_else(|| match self.settings.data_source {
-                    DataSource::LmSensors => self.settings.metric_type.default_threshold(),
+                    DataSource::LmSensors => {
+                        let default = self.settings.metric_type.default_threshold();
+                        // In GB mode, scale the percentage-based threshold to GB
+                        match self.settings.metric_type {
+                            MetricType::GpuVram if self.settings.memory_display() == MemoryDisplay::Gigabytes => {
+                                self.vram_total_gb.and_then(|total| default.map(|d| d / 100.0 * total))
+                            }
+                            MetricType::RamUsage if self.settings.memory_display() == MemoryDisplay::Gigabytes => {
+                                self.ram_total_gb.and_then(|total| default.map(|d| d / 100.0 * total))
+                            }
+                            _ => default,
+                        }
+                    }
                     DataSource::WebSocket => None,
                 }),
             color_scheme: ColorScheme {

--- a/src/graph_data.rs
+++ b/src/graph_data.rs
@@ -11,7 +11,8 @@ const MAX_DATA_POINTS: usize = 60;
 #[serde(rename_all = "lowercase")]
 pub enum DataSource {
     #[default]
-    LmSensors,
+    #[serde(alias = "lmsensors")]
+    Local,
     WebSocket,
 }
 
@@ -221,7 +222,7 @@ impl GraphData {
 
         // Title is always the metric name only (displayed on the graph image)
         let title = match self.settings.data_source {
-            DataSource::LmSensors => {
+            DataSource::Local => {
                 // For system fan, show the fan number
                 if matches!(self.settings.metric_type, MetricType::SystemFan) {
                     if let Some(fan_num) = self.settings.fan_number {
@@ -250,7 +251,7 @@ impl GraphData {
                 .settings
                 .max_value
                 .unwrap_or_else(|| match self.settings.data_source {
-                    DataSource::LmSensors => {
+                    DataSource::Local => {
                         let detected_total = match self.settings.metric_type {
                             MetricType::GpuVram if self.settings.memory_display() == MemoryDisplay::Gigabytes => self.vram_total_gb,
                             MetricType::RamUsage if self.settings.memory_display() == MemoryDisplay::Gigabytes => self.ram_total_gb,
@@ -265,7 +266,7 @@ impl GraphData {
                 .settings
                 .threshold
                 .or_else(|| match self.settings.data_source {
-                    DataSource::LmSensors => {
+                    DataSource::Local => {
                         let default = self.settings.metric_type.default_threshold();
                         // In GB mode, scale the percentage-based threshold to GB
                         match self.settings.metric_type {

--- a/src/graph_data.rs
+++ b/src/graph_data.rs
@@ -23,6 +23,14 @@ pub enum VisualizationType {
     Gauge,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryDisplay {
+    #[default]
+    Percentage,
+    Gigabytes,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MetricType {
@@ -31,6 +39,8 @@ pub enum MetricType {
     CpuLoad,
     GpuTemp,
     GpuLoad,
+    GpuVram,
+    GpuPower,
     MotherboardTemp,
     NvmeTemp,
     SystemFan,
@@ -58,7 +68,8 @@ impl MetricType {
             | MetricType::MotherboardTemp
             | MetricType::NvmeTemp
             | MetricType::RamTemp => 120.0,
-            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::RamUsage => 100.0,
+            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::GpuVram | MetricType::RamUsage => 100.0,
+            MetricType::GpuPower => 500.0,
             MetricType::SystemFan => 3000.0,
             MetricType::CpuVoltage => 2.0,
             MetricType::DiskWrite | MetricType::DiskRead => 500.0, // MB/s
@@ -69,7 +80,8 @@ impl MetricType {
     pub fn default_threshold(&self) -> Option<f32> {
         match self {
             MetricType::CpuTemp | MetricType::CpuPackageTemp => Some(80.0),
-            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::RamUsage => Some(80.0),
+            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::GpuVram | MetricType::RamUsage => Some(80.0),
+            MetricType::GpuPower => Some(300.0),
             MetricType::GpuTemp => Some(85.0),
             MetricType::MotherboardTemp => Some(60.0),
             MetricType::NvmeTemp => Some(70.0),
@@ -85,6 +97,8 @@ impl MetricType {
             MetricType::CpuLoad => "CPU Load",
             MetricType::GpuTemp => "GPU Temp",
             MetricType::GpuLoad => "GPU Load",
+            MetricType::GpuVram => "GPU VRAM",
+            MetricType::GpuPower => "GPU Power",
             MetricType::MotherboardTemp => "Motherboard",
             MetricType::NvmeTemp => "NVMe Temp",
             MetricType::SystemFan => "System Fan",
@@ -106,7 +120,8 @@ impl MetricType {
             | MetricType::MotherboardTemp
             | MetricType::NvmeTemp
             | MetricType::RamTemp => "°C",
-            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::RamUsage => "%",
+            MetricType::CpuLoad | MetricType::GpuLoad | MetricType::GpuVram | MetricType::RamUsage => "%",
+            MetricType::GpuPower => "W",
             MetricType::SystemFan => " RPM",
             MetricType::CpuVoltage => "V",
             MetricType::DiskWrite | MetricType::DiskRead => " MB/s",
@@ -144,6 +159,30 @@ pub struct GraphSettings {
 
     // GPU selection
     pub gpu_card: Option<String>,
+
+    // Memory display mode (percentage vs gigabytes)
+    pub vram_display: MemoryDisplay,
+    pub ram_display: MemoryDisplay,
+}
+
+impl GraphSettings {
+    pub fn memory_display(&self) -> MemoryDisplay {
+        match self.metric_type {
+            MetricType::GpuVram => self.vram_display,
+            MetricType::RamUsage => self.ram_display,
+            _ => MemoryDisplay::Percentage,
+        }
+    }
+
+    pub fn effective_suffix(&self) -> &str {
+        if matches!(self.metric_type, MetricType::GpuVram | MetricType::RamUsage)
+            && self.memory_display() == MemoryDisplay::Gigabytes
+        {
+            "GB"
+        } else {
+            self.metric_type.value_suffix()
+        }
+    }
 }
 
 /// Data for a single graph instance
@@ -151,6 +190,9 @@ pub struct GraphData {
     data_points: VecDeque<f32>,
     pub settings: GraphSettings,
     ws_client: Option<Arc<WebSocketClient>>,
+    /// Cached total memory in GB (auto-detected, used for graph max and display)
+    pub vram_total_gb: Option<f32>,
+    pub ram_total_gb: Option<f32>,
 }
 
 impl GraphData {
@@ -159,6 +201,8 @@ impl GraphData {
             data_points: VecDeque::with_capacity(MAX_DATA_POINTS),
             settings,
             ws_client: None,
+            vram_total_gb: None,
+            ram_total_gb: None,
         }
     }
 
@@ -185,6 +229,14 @@ impl GraphData {
                     } else {
                         "Fan 1".to_string()
                     }
+                } else if matches!(self.settings.metric_type, MetricType::GpuVram | MetricType::RamUsage)
+                    && self.settings.memory_display() == MemoryDisplay::Gigabytes
+                {
+                    match self.settings.metric_type {
+                        MetricType::GpuVram => "VRAM GB".to_string(),
+                        MetricType::RamUsage => "RAM GB".to_string(),
+                        _ => unreachable!(),
+                    }
                 } else {
                     self.settings.metric_type.display_name().to_string()
                 }
@@ -198,7 +250,14 @@ impl GraphData {
                 .settings
                 .max_value
                 .unwrap_or_else(|| match self.settings.data_source {
-                    DataSource::LmSensors => self.settings.metric_type.default_max(),
+                    DataSource::LmSensors => {
+                        let detected_total = match self.settings.metric_type {
+                            MetricType::GpuVram if self.settings.memory_display() == MemoryDisplay::Gigabytes => self.vram_total_gb,
+                            MetricType::RamUsage if self.settings.memory_display() == MemoryDisplay::Gigabytes => self.ram_total_gb,
+                            _ => None,
+                        };
+                        detected_total.unwrap_or_else(|| self.settings.metric_type.default_max())
+                    }
                     DataSource::WebSocket => 100.0,
                 }),
             min_value: self.settings.min_value.unwrap_or(0.0),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -148,7 +148,13 @@ impl Action for GraphAction {
 
         if let Some(graph_data) = instances.get_mut(&instance_id) {
             let old_source = graph_data.settings.data_source.clone();
+            let old_gpu_card = graph_data.settings.gpu_card.clone();
             graph_data.settings = settings.clone();
+
+            // Invalidate cached memory totals when the monitored GPU changes
+            if settings.gpu_card != old_gpu_card {
+                graph_data.vram_total_gb = None;
+            }
 
             // Reinitialize WebSocket if source changed to WebSocket
             if settings.data_source == DataSource::WebSocket && old_source != DataSource::WebSocket

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -22,7 +22,7 @@ async fn read_sensor_value(
     ws_client: Option<&Arc<WebSocketClient>>,
 ) -> Result<f32> {
     match settings.data_source {
-        DataSource::LmSensors => read_lm_sensors_value(settings).await,
+        DataSource::Local => read_local_sensor_value(settings).await,
         DataSource::WebSocket => {
             if let Some(client) = ws_client {
                 Ok(client.get_value().await)
@@ -33,7 +33,7 @@ async fn read_sensor_value(
     }
 }
 
-async fn read_lm_sensors_value(settings: &GraphSettings) -> Result<f32> {
+async fn read_local_sensor_value(settings: &GraphSettings) -> Result<f32> {
     match settings.metric_type {
         MetricType::CpuTemp | MetricType::CpuPackageTemp => sensors::find_cpu_temperature().await,
         MetricType::CpuLoad => sensors::find_cpu_load().await,
@@ -229,7 +229,7 @@ pub async fn start_sensor_monitoring() {
                                 }
                             } else {
                                 let suffix = match graph_data.settings.data_source {
-                                    DataSource::LmSensors => {
+                                    DataSource::Local => {
                                         graph_data.settings.effective_suffix()
                                     }
                                     DataSource::WebSocket => "",

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{interval, Duration};
 
-use crate::graph_data::{DataSource, GraphData, GraphSettings, MetricType, VisualizationType};
+use crate::graph_data::{DataSource, GraphData, GraphSettings, MemoryDisplay, MetricType, VisualizationType};
 use crate::sensors;
 use crate::websocket::WebSocketClient;
 
@@ -45,6 +45,17 @@ async fn read_lm_sensors_value(settings: &GraphSettings) -> Result<f32> {
             let card = settings.gpu_card.as_deref().unwrap_or("card0");
             sensors::find_gpu_load(card).await
         }
+        MetricType::GpuVram => {
+            let card = settings.gpu_card.as_deref().unwrap_or("card0");
+            match settings.vram_display {
+                MemoryDisplay::Percentage => sensors::find_gpu_vram(card).await,
+                MemoryDisplay::Gigabytes => sensors::find_gpu_vram_gb(card).await,
+            }
+        }
+        MetricType::GpuPower => {
+            let card = settings.gpu_card.as_deref().unwrap_or("card0");
+            sensors::find_gpu_power(card).await
+        }
         MetricType::MotherboardTemp => sensors::find_motherboard_temperature().await,
         MetricType::NvmeTemp => sensors::find_nvme_temperature().await,
         MetricType::SystemFan => {
@@ -53,7 +64,12 @@ async fn read_lm_sensors_value(settings: &GraphSettings) -> Result<f32> {
         MetricType::CpuVoltage => sensors::find_cpu_voltage().await,
         MetricType::DiskWrite => sensors::find_disk_write().await,
         MetricType::DiskRead => sensors::find_disk_read().await,
-        MetricType::RamUsage => sensors::find_ram_usage().await,
+        MetricType::RamUsage => {
+            match settings.ram_display {
+                MemoryDisplay::Percentage => sensors::find_ram_usage().await,
+                MemoryDisplay::Gigabytes => sensors::find_ram_usage_gb().await,
+            }
+        }
         MetricType::NetDownload => sensors::find_net_download().await,
         MetricType::NetUpload => sensors::find_net_upload().await,
         MetricType::RamTemp => sensors::find_ram_temperature().await,
@@ -162,6 +178,28 @@ pub async fn start_sensor_monitoring() {
                 let mut instances = GRAPH_INSTANCES.lock().await;
 
                 if let Some(graph_data) = instances.get_mut(&instance_id) {
+                    // Cache memory totals when in GB mode (before borrowing ws_client)
+                    if graph_data.settings.memory_display() == MemoryDisplay::Gigabytes {
+                        match graph_data.settings.metric_type {
+                            MetricType::GpuVram if graph_data.vram_total_gb.is_none() => {
+                                let card = graph_data.settings.gpu_card.as_deref().unwrap_or("card0");
+                                if let Ok(total) = sensors::find_gpu_vram_total_gb(card).await {
+                                    if total > 0.0 {
+                                        graph_data.vram_total_gb = Some(total);
+                                    }
+                                }
+                            }
+                            MetricType::RamUsage if graph_data.ram_total_gb.is_none() => {
+                                if let Ok(total) = sensors::find_ram_total_gb().await {
+                                    if total > 0.0 {
+                                        graph_data.ram_total_gb = Some(total);
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+
                     let ws_client = graph_data.get_ws_client();
 
                     if let Ok(value) = read_sensor_value(&graph_data.settings, ws_client).await {
@@ -171,13 +209,27 @@ pub async fn start_sensor_monitoring() {
 
                         // Prepare title text before dropping instances
                         let title_option = if graph_data.settings.show_value_text {
-                            let suffix = match graph_data.settings.data_source {
-                                DataSource::LmSensors => {
-                                    graph_data.settings.metric_type.value_suffix()
+                            // Show "X.X/Y.YGB" for memory metrics in GB mode
+                            if graph_data.settings.memory_display() == MemoryDisplay::Gigabytes {
+                                let total = match graph_data.settings.metric_type {
+                                    MetricType::GpuVram => graph_data.vram_total_gb,
+                                    MetricType::RamUsage => graph_data.ram_total_gb,
+                                    _ => None,
+                                };
+                                if let Some(total) = total {
+                                    Some(format!("{:.1}/{:.0}GB", value, total))
+                                } else {
+                                    Some(format!("{:.1}GB", value))
                                 }
-                                DataSource::WebSocket => "",
-                            };
-                            Some(format!("{:.1}{}", value, suffix))
+                            } else {
+                                let suffix = match graph_data.settings.data_source {
+                                    DataSource::LmSensors => {
+                                        graph_data.settings.effective_suffix()
+                                    }
+                                    DataSource::WebSocket => "",
+                                };
+                                Some(format!("{:.1}{}", value, suffix))
+                            }
                         } else {
                             None
                         };

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -647,7 +647,7 @@ fn first_hwmon_dir(base: &str) -> Option<String> {
     None
 }
 
-/// Find motherboard temperature from lm-sensors
+/// Find motherboard temperature via hwmon sysfs
 pub async fn find_motherboard_temperature() -> Result<f32> {
     for (hwmon_path, chip_name) in iter_hwmon() {
         if !chip_name.contains("nct") && !chip_name.contains("it87") {

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use lm_sensors as sensors;
 use std::fs;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use sysinfo::{Components, Disks, MemoryRefreshKind, Networks, System};
 
 static PREV_CPU_STATS: Mutex<Option<(u64, u64)>> = Mutex::new(None);
@@ -10,6 +10,21 @@ static PREV_DISK_WRITE: Mutex<Option<u64>> = Mutex::new(None);
 static PREV_DISK_READ: Mutex<Option<u64>> = Mutex::new(None);
 static PREV_NET_RX: Mutex<Option<u64>> = Mutex::new(None);
 static PREV_NET_TX: Mutex<Option<u64>> = Mutex::new(None);
+static NVML: OnceLock<Option<nvml_wrapper::Nvml>> = OnceLock::new();
+static SYSINFO: Mutex<Option<System>> = Mutex::new(None);
+
+/// Get the shared NVML instance, initializing it once on first use.
+fn nvml() -> Option<&'static nvml_wrapper::Nvml> {
+    NVML.get_or_init(|| nvml_wrapper::Nvml::init().ok()).as_ref()
+}
+
+/// Get RAM info (used, total) using a shared System instance.
+fn ram_info() -> (u64, u64) {
+    let mut guard = SYSINFO.lock().unwrap();
+    let sys = guard.get_or_insert_with(System::new);
+    sys.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
+    (sys.used_memory(), sys.total_memory())
+}
 
 #[derive(Debug, Clone, Copy)]
 enum GpuVendor {
@@ -57,10 +72,10 @@ pub fn list_gpus() -> Vec<GpuInfo> {
 
     // Check for NVIDIA GPUs via NVML
     if Path::new("/proc/driver/nvidia/version").exists() {
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(count) = nvml.device_count() {
+        if let Some(nv) = nvml() {
+            if let Ok(count) = nv.device_count() {
                 for i in 0..count {
-                    if let Ok(device) = nvml.device_by_index(i) {
+                    if let Ok(device) = nv.device_by_index(i) {
                         let name = device.name().unwrap_or_else(|_| format!("NVIDIA GPU {}", i));
                         gpus.push(GpuInfo {
                             card: format!("nvidia:{}", i),
@@ -188,14 +203,7 @@ pub async fn find_cpu_load() -> Result<f32> {
 
 /// Find RAM usage percentage
 pub async fn find_ram_usage() -> Result<f32> {
-    let mut sys = System::new();
-    sys.refresh_memory_specifics(
-        MemoryRefreshKind::nothing().with_ram(),
-    );
-
-    let total = sys.total_memory();
-    let used = sys.used_memory();
-
+    let (used, total) = ram_info();
     if total > 0 {
         Ok((used as f32 / total as f32) * 100.0)
     } else {
@@ -205,22 +213,14 @@ pub async fn find_ram_usage() -> Result<f32> {
 
 /// Find RAM usage in gigabytes
 pub async fn find_ram_usage_gb() -> Result<f32> {
-    let mut sys = System::new();
-    sys.refresh_memory_specifics(
-        MemoryRefreshKind::nothing().with_ram(),
-    );
-
-    Ok(sys.used_memory() as f32 / 1_073_741_824.0)
+    let (used, _) = ram_info();
+    Ok(used as f32 / 1_073_741_824.0)
 }
 
 /// Find total RAM in gigabytes
 pub async fn find_ram_total_gb() -> Result<f32> {
-    let mut sys = System::new();
-    sys.refresh_memory_specifics(
-        MemoryRefreshKind::nothing().with_ram(),
-    );
-
-    Ok(sys.total_memory() as f32 / 1_073_741_824.0)
+    let (_, total) = ram_info();
+    Ok(total as f32 / 1_073_741_824.0)
 }
 
 /// Find RAM temperature from sysinfo
@@ -358,8 +358,8 @@ pub async fn find_cpu_temperature() -> Result<f32> {
 pub async fn find_gpu_load(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(utilization) = device.utilization_rates() {
                     return Ok(utilization.gpu as f32);
                 }
@@ -376,8 +376,8 @@ pub async fn find_gpu_load(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(utilization) = device.utilization_rates() {
                             return Ok(utilization.gpu as f32);
                         }
@@ -396,8 +396,8 @@ pub async fn find_gpu_load(card: &str) -> Result<f32> {
 pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(temp) = device
                     .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
                 {
@@ -421,8 +421,8 @@ pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(temp) = device
                             .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
                         {
@@ -443,8 +443,8 @@ pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
 pub async fn find_gpu_vram(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(mem_info) = device.memory_info() {
                     let pct = (mem_info.used as f64 / mem_info.total as f64) * 100.0;
                     return Ok(pct as f32);
@@ -464,8 +464,8 @@ pub async fn find_gpu_vram(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(mem_info) = device.memory_info() {
                             let pct = (mem_info.used as f64 / mem_info.total as f64) * 100.0;
                             return Ok(pct as f32);
@@ -485,8 +485,8 @@ pub async fn find_gpu_vram(card: &str) -> Result<f32> {
 pub async fn find_gpu_vram_gb(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(mem_info) = device.memory_info() {
                     return Ok(mem_info.used as f32 / 1_073_741_824.0);
                 }
@@ -501,8 +501,8 @@ pub async fn find_gpu_vram_gb(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(mem_info) = device.memory_info() {
                             return Ok(mem_info.used as f32 / 1_073_741_824.0);
                         }
@@ -521,8 +521,8 @@ pub async fn find_gpu_vram_gb(card: &str) -> Result<f32> {
 pub async fn find_gpu_vram_total_gb(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(mem_info) = device.memory_info() {
                     return Ok(mem_info.total as f32 / 1_073_741_824.0);
                 }
@@ -537,8 +537,8 @@ pub async fn find_gpu_vram_total_gb(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(mem_info) = device.memory_info() {
                             return Ok(mem_info.total as f32 / 1_073_741_824.0);
                         }
@@ -557,8 +557,8 @@ pub async fn find_gpu_vram_total_gb(card: &str) -> Result<f32> {
 pub async fn find_gpu_power(card: &str) -> Result<f32> {
     if let Some(idx_str) = card.strip_prefix("nvidia:") {
         let idx: u32 = idx_str.parse().unwrap_or(0);
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(idx) {
+        if let Some(nv) = nvml() {
+            if let Ok(device) = nv.device_by_index(idx) {
                 if let Ok(power_mw) = device.power_usage() {
                     return Ok(power_mw as f32 / 1000.0);
                 }
@@ -567,8 +567,8 @@ pub async fn find_gpu_power(card: &str) -> Result<f32> {
     } else {
         match detect_gpu_vendor_for_card(card) {
             GpuVendor::Amd => {
-                let pattern = format!("/sys/class/drm/{}/device/hwmon/hwmon*", card);
-                if let Ok(path) = glob_first_path(&pattern) {
+                let hwmon_path = format!("/sys/class/drm/{}/device/hwmon", card);
+                if let Some(path) = first_hwmon_dir(&hwmon_path) {
                     let power_path = format!("{}/power1_average", path);
                     if let Ok(microwatts) = read_sysfs_f32(&power_path) {
                         return Ok(microwatts / 1_000_000.0);
@@ -576,8 +576,8 @@ pub async fn find_gpu_power(card: &str) -> Result<f32> {
                 }
             }
             GpuVendor::Nvidia => {
-                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-                    if let Ok(device) = nvml.device_by_index(0) {
+                if let Some(nv) = nvml() {
+                    if let Ok(device) = nv.device_by_index(0) {
                         if let Ok(power_mw) = device.power_usage() {
                             return Ok(power_mw as f32 / 1000.0);
                         }
@@ -598,16 +598,16 @@ fn read_sysfs_f32(path: &str) -> Result<f32> {
     Ok(content.trim().parse()?)
 }
 
-/// Return the first match for a glob pattern as a string path
-fn glob_first_path(pattern: &str) -> Result<String> {
-    let output = std::process::Command::new("sh")
-        .args(["-c", &format!("ls -1d {} 2>/dev/null | head -1", pattern)])
-        .output()?;
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() {
-        anyhow::bail!("no match for glob: {}", pattern);
+/// Return the first hwmon directory path inside the given base directory.
+fn first_hwmon_dir(base: &str) -> Option<String> {
+    let entries = fs::read_dir(base).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("hwmon") {
+            return Some(entry.path().to_string_lossy().into_owned());
+        }
     }
-    Ok(path)
+    None
 }
 
 /// Find motherboard temperature from lm-sensors

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -203,6 +203,26 @@ pub async fn find_ram_usage() -> Result<f32> {
     }
 }
 
+/// Find RAM usage in gigabytes
+pub async fn find_ram_usage_gb() -> Result<f32> {
+    let mut sys = System::new();
+    sys.refresh_memory_specifics(
+        MemoryRefreshKind::nothing().with_ram(),
+    );
+
+    Ok(sys.used_memory() as f32 / 1_073_741_824.0)
+}
+
+/// Find total RAM in gigabytes
+pub async fn find_ram_total_gb() -> Result<f32> {
+    let mut sys = System::new();
+    sys.refresh_memory_specifics(
+        MemoryRefreshKind::nothing().with_ram(),
+    );
+
+    Ok(sys.total_memory() as f32 / 1_073_741_824.0)
+}
+
 /// Find RAM temperature from sysinfo
 pub async fn find_ram_temperature() -> Result<f32> {
     let components = Components::new_with_refreshed_list();
@@ -417,6 +437,177 @@ pub async fn find_gpu_temperature(card: &str) -> Result<f32> {
 
     log::warn!("GPU temperature sensor not found for card: {}", card);
     Ok(0.0)
+}
+
+/// Find GPU VRAM usage percentage for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_vram(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(mem_info) = device.memory_info() {
+                    let pct = (mem_info.used as f64 / mem_info.total as f64) * 100.0;
+                    return Ok(pct as f32);
+                }
+            }
+        }
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let base = format!("/sys/class/drm/{}/device", card);
+                let used = read_sysfs_f32(&format!("{}/mem_info_vram_used", base));
+                let total = read_sysfs_f32(&format!("{}/mem_info_vram_total", base));
+                if let (Ok(u), Ok(t)) = (used, total) {
+                    if t > 0.0 {
+                        return Ok((u / t) * 100.0);
+                    }
+                }
+            }
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(mem_info) = device.memory_info() {
+                            let pct = (mem_info.used as f64 / mem_info.total as f64) * 100.0;
+                            return Ok(pct as f32);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    log::warn!("GPU VRAM sensor not found for card: {}", card);
+    Ok(0.0)
+}
+
+/// Find GPU VRAM usage in gigabytes for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_vram_gb(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(mem_info) = device.memory_info() {
+                    return Ok(mem_info.used as f32 / 1_073_741_824.0);
+                }
+            }
+        }
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let base = format!("/sys/class/drm/{}/device", card);
+                if let Ok(used) = read_sysfs_f32(&format!("{}/mem_info_vram_used", base)) {
+                    return Ok(used / 1_073_741_824.0);
+                }
+            }
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(mem_info) = device.memory_info() {
+                            return Ok(mem_info.used as f32 / 1_073_741_824.0);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    log::warn!("GPU VRAM sensor not found for card: {}", card);
+    Ok(0.0)
+}
+
+/// Find total GPU VRAM in gigabytes for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_vram_total_gb(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(mem_info) = device.memory_info() {
+                    return Ok(mem_info.total as f32 / 1_073_741_824.0);
+                }
+            }
+        }
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let base = format!("/sys/class/drm/{}/device", card);
+                if let Ok(total) = read_sysfs_f32(&format!("{}/mem_info_vram_total", base)) {
+                    return Ok(total / 1_073_741_824.0);
+                }
+            }
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(mem_info) = device.memory_info() {
+                            return Ok(mem_info.total as f32 / 1_073_741_824.0);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    log::warn!("GPU VRAM total not found for card: {}", card);
+    Ok(0.0)
+}
+
+/// Find GPU power draw in watts for a specific card (e.g. "card0" or "nvidia:0")
+pub async fn find_gpu_power(card: &str) -> Result<f32> {
+    if let Some(idx_str) = card.strip_prefix("nvidia:") {
+        let idx: u32 = idx_str.parse().unwrap_or(0);
+        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+            if let Ok(device) = nvml.device_by_index(idx) {
+                if let Ok(power_mw) = device.power_usage() {
+                    return Ok(power_mw as f32 / 1000.0);
+                }
+            }
+        }
+    } else {
+        match detect_gpu_vendor_for_card(card) {
+            GpuVendor::Amd => {
+                let pattern = format!("/sys/class/drm/{}/device/hwmon/hwmon*", card);
+                if let Ok(path) = glob_first_path(&pattern) {
+                    let power_path = format!("{}/power1_average", path);
+                    if let Ok(microwatts) = read_sysfs_f32(&power_path) {
+                        return Ok(microwatts / 1_000_000.0);
+                    }
+                }
+            }
+            GpuVendor::Nvidia => {
+                if let Ok(nvml) = nvml_wrapper::Nvml::init() {
+                    if let Ok(device) = nvml.device_by_index(0) {
+                        if let Ok(power_mw) = device.power_usage() {
+                            return Ok(power_mw as f32 / 1000.0);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    log::warn!("GPU power sensor not found for card: {}", card);
+    Ok(0.0)
+}
+
+/// Read a sysfs file as f32
+fn read_sysfs_f32(path: &str) -> Result<f32> {
+    let content = fs::read_to_string(path)?;
+    Ok(content.trim().parse()?)
+}
+
+/// Return the first match for a glob pattern as a string path
+fn glob_first_path(pattern: &str) -> Result<String> {
+    let output = std::process::Command::new("sh")
+        .args(["-c", &format!("ls -1d {} 2>/dev/null | head -1", pattern)])
+        .output()?;
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        anyhow::bail!("no match for glob: {}", pattern);
+    }
+    Ok(path)
 }
 
 /// Find motherboard temperature from lm-sensors


### PR DESCRIPTION
## Summary

  - Add two new GPU metrics: VRAM usage and power draw (watts), with support for both NVIDIA (via `NVML`) and AMD (via `sysfs`)
  - Add configurable display mode for VRAM and RAM metrics — users can choose between percentage and absolute GB display, with auto-detected totals for graph scaling and "X.X/Y.YGB" value text
  - Efficiency improvements: NVML is now initialized once via OnceLock instead of per-call, and sysinfo System is shared via a static Mutex for RAM queries
  - Rename `DataSource::LmSensors` to `DataSource::Local` (with serde alias for backward compatibility with existing configs), drawing on #7  

## Details

  - New `MetricType` variants: `GpuVram`, `GpuPower`
  - New `MemoryDisplay` enum (Percentage / Gigabytes) with per-metric settings (`vram_display`, `ram_display`)
  - GraphData caches detected memory totals (`vram_total_gb`, `ram_total_gb`) to avoid repeated lookups; cache invalidates when GPU card selection changes
  - Thresholds and graph max values scale automatically in GB mode
  - Property inspector UI adds VRAM/RAM display mode dropdowns and extends GPU card selector to new GPU metrics
  - Helper functions `read_sysfs_f32` and `first_hwmon_dir` for AMD `sysfs` reads

## Tested with

  - Two hardware versions:
      - StreamDeck MK2
      - StreamDeck+
  - Verify GPU VRAM % and GB display on NVIDIA GPU
  - Verify GPU VRAM % and GB display on AMD GPU
  - Verify GPU power draw reading on NVIDIA and AMD
  - Verify RAM usage in both % and GB modes
  - Confirm graph max auto-scales to total VRAM/RAM in GB mode
  - Confirm value text shows "X.X/Y.YGB" format in GB mode
  - Confirm GPU card dropdown appears for VRAM and power metrics
  - Test switching between display modes preserves correct state
  - Cross-verified with a standalone OpenAction GPU plugin I created (https://github.com/asetapen/linux-gpu-monitor)

## Screenshots

<img width="917" height="981" alt="streamdeck" src="https://github.com/user-attachments/assets/7c4acb1c-c6a1-482e-9fb8-687a5d5efdd4" />

<img width="654" height="517" alt="streamdeckplus" src="https://github.com/user-attachments/assets/ecfa2332-2c6d-4797-882c-7d067e7b9ac1" />