### PR TITLE
Migrate older graph cells to proper datasource

### DIFF
--- a/pi.html
+++ b/pi.html
@@ -101,6 +101,7 @@
 
                 function applySettings(s) {
                     dataSource.value = s.data_source || "local";
+                    if (!dataSource.value) dataSource.value = "local";
                     visualizationType.value = s.visualization_type || "graph";
                     metricType.value = s.metric_type || "cputemp";
                     fanNumber.value = s.fan_number ?? 1;


### PR DESCRIPTION
After https://github.com/mdvictor/opendeck-graphs/commit/b78eac1f0e99948d78fd40d4ce52e44463b3822b the inspector was never migrated properly. The datasource needed to be explicitly re-selected from the UI because the old `lmsensors` value was no longer an option so the select defaulted to nothing.
